### PR TITLE
support Boost 1.70.0 (without dropping older Boost support)

### DIFF
--- a/BeastHttp/include/http/base/impl/socket.hxx
+++ b/BeastHttp/include/http/base/impl/socket.hxx
@@ -5,10 +5,9 @@ namespace _0xdead4ead {
 namespace http {
 namespace base {
 
-template<class Protocol,
-         template<typename> class Socket>
+template<class Socket>
 boost::system::error_code
-socket<Protocol, Socket>::shutdown(typename socket_type::shutdown_type type)
+socket<Socket>::shutdown(typename socket_type::shutdown_type type)
 {
     auto ec = boost::system::error_code{};
     instance_.shutdown(type, ec);
@@ -16,10 +15,9 @@ socket<Protocol, Socket>::shutdown(typename socket_type::shutdown_type type)
     return ec;
 }
 
-template<class Protocol,
-         template<typename> class Socket>
+template<class Socket>
 boost::system::error_code
-socket<Protocol, Socket>::close()
+socket<Socket>::close()
 {
     auto ec = boost::system::error_code{};
     instance_.close(ec);
@@ -27,9 +25,8 @@ socket<Protocol, Socket>::close()
     return ec;
 }
 
-template<class Protocol,
-         template<typename> class Socket>
-socket<Protocol, Socket>::socket(socket_type&& socket)
+template<class Socket>
+socket<Socket>::socket(socket_type&& socket)
     : instance_{std::move(socket)}
 {
 }

--- a/BeastHttp/include/http/base/impl/timer.hxx
+++ b/BeastHttp/include/http/base/impl/timer.hxx
@@ -2,6 +2,7 @@
 #define BEASTHTTP_BASE_IMPL_TIMER_HXX
 
 #include <boost/asio/bind_executor.hpp>
+#include <boost/asio/version.hpp>
 
 namespace _0xdead4ead {
 namespace http {
@@ -14,7 +15,11 @@ timer<Clock, Timer, CompletionExecutor>::timer(
         const CompletionExecutor& completion_executor,
         const TimePointOrDuration duration_or_time)
     : completion_executor_{completion_executor},
-      timer_{completion_executor.get_inner_executor().context(), duration_or_time}
+      timer_{completion_executor.get_inner_executor()
+#if BOOST_ASIO_VERSION < 101400
+        .context()
+#endif
+      , duration_or_time}
 {
 }
 

--- a/BeastHttp/include/http/base/socket.hxx
+++ b/BeastHttp/include/http/base/socket.hxx
@@ -5,23 +5,22 @@
 #include <boost/system/error_code.hpp>
 
 #define BEASTHTTP_SOCKET_TMPL_ATTRIBUTES \
-    Protocol, Socket
+    Socket
 
 namespace _0xdead4ead {
 namespace http {
 namespace base {
 
-template<class Protocol,
-         template<typename> class Socket>
+template<class Socket>
 class socket
 {
     using self_type = socket;
 
 protected:
 
-    using protocol_type = Protocol;
+    using protocol_type = typename Socket::protocol_type;
 
-    using socket_type = Socket<protocol_type>;
+    using socket_type = Socket;
 
     static_assert (std::is_base_of<boost::asio::socket_base, socket_type>::value,
                    "Socket type is not supported!");

--- a/BeastHttp/include/http/base/strand_stream.hxx
+++ b/BeastHttp/include/http/base/strand_stream.hxx
@@ -3,17 +3,18 @@
 
 #include <boost/asio/strand.hpp>
 #include <boost/asio/io_context.hpp>
+#include <boost/asio/system_timer.hpp>
 
 namespace _0xdead4ead {
 namespace http {
 namespace base {
 
 struct strand_stream :
-        boost::asio::strand<boost::asio::io_context::executor_type>
+        boost::asio::strand<boost::asio::system_timer::executor_type>
 {
-    using asio_type = boost::asio::strand<boost::asio::io_context::executor_type>;
+    using asio_type = boost::asio::strand<boost::asio::system_timer::executor_type>;
 
-    strand_stream(const boost::asio::io_context::executor_type& executor)
+    strand_stream(const boost::asio::system_timer::executor_type& executor)
         : asio_type(executor)
     {
     }

--- a/BeastHttp/include/http/common/connection.hxx
+++ b/BeastHttp/include/http/common/connection.hxx
@@ -8,8 +8,7 @@ namespace _0xdead4ead {
 namespace http {
 namespace common {
 
-template<class Protocol,
-         template<typename> class Socket,
+template<class Socket,
          class CompletionExecutor>
 class connection :
         private base::socket<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES>,

--- a/BeastHttp/include/http/common/impl/connection.hxx
+++ b/BeastHttp/include/http/common/impl/connection.hxx
@@ -5,8 +5,7 @@ namespace _0xdead4ead {
 namespace http {
 namespace common {
 
-template<class Protocol,
-         template<typename> class Socket,
+template<class Socket,
          class CompletionExecutor>
 connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::connection(
         socket_type&& socket,
@@ -17,8 +16,7 @@ connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::connection(
 {
 }
 
-template<class Protocol,
-         template<typename> class Socket,
+template<class Socket,
          class CompletionExecutor>
 boost::beast::error_code
 connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::shutdown(shutdown_type type)
@@ -26,8 +24,7 @@ connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::shutdown(shutd
     return base_socket::shutdown(type);
 }
 
-template<class Protocol,
-         template<typename> class Socket,
+template<class Socket,
          class CompletionExecutor>
 boost::beast::error_code
 connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::close()
@@ -35,8 +32,7 @@ connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::close()
     return base_socket::close();
 }
 
-template<class Protocol,
-         template<typename> class Socket,
+template<class Socket,
          class CompletionExecutor>
 typename connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::socket_type&
 connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::stream()

--- a/BeastHttp/include/http/common/ssl/connection.hxx
+++ b/BeastHttp/include/http/common/ssl/connection.hxx
@@ -11,8 +11,7 @@ namespace http {
 namespace common {
 namespace ssl {
 
-template<class Protocol,
-         template<typename> class Socket,
+template<class Socket,
          class CompletionExecutor>
 class connection : private base::socket<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES>,
         public base::connection<connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>,

--- a/BeastHttp/include/http/common/ssl/impl/connection.hxx
+++ b/BeastHttp/include/http/common/ssl/impl/connection.hxx
@@ -6,8 +6,7 @@ namespace http {
 namespace common {
 namespace ssl {
 
-template<class Protocol,
-         template<typename> class Socket,
+template<class Socket,
          class CompletionExecutor>
 connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::connection(
         socket_type&& socket, boost::asio::ssl::context& ctx,
@@ -18,8 +17,7 @@ connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::connection(
 {
 }
 
-template<class Protocol,
-         template<typename> class Socket,
+template<class Socket,
          class CompletionExecutor>
 template <class F, class B>
 void
@@ -32,8 +30,7 @@ connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::async_handshak
                                            std::forward<F>(f)));
 }
 
-template<class Protocol,
-         template<typename> class Socket,
+template<class Socket,
          class CompletionExecutor>
 template<class F>
 void
@@ -44,8 +41,7 @@ connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::async_shutdown
                                            std::forward<F>(f)));
 }
 
-template<class Protocol,
-         template<typename> class Socket,
+template<class Socket,
          class CompletionExecutor>
 boost::beast::error_code
 connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::force_shutdown(shutdown_type type)
@@ -53,8 +49,7 @@ connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::force_shutdown
     return base_socket::shutdown(type);
 }
 
-template<class Protocol,
-         template<typename> class Socket,
+template<class Socket,
          class CompletionExecutor>
 boost::beast::error_code
 connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::force_close()
@@ -62,8 +57,7 @@ connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::force_close()
     return base_socket::close();
 }
 
-template<class Protocol,
-         template<typename> class Socket,
+template<class Socket,
          class CompletionExecutor>
 typename connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::ssl_stream_type&
 connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::stream()
@@ -71,8 +65,7 @@ connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::stream()
     return stream_;
 }
 
-template<class Protocol,
-         template<typename> class Socket,
+template<class Socket,
          class CompletionExecutor>
 typename connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::socket_type&
 connection<BEASTHTTP_SOCKET_TMPL_ATTRIBUTES, CompletionExecutor>::socket()

--- a/BeastHttp/include/http/reactor/impl/listener.hxx
+++ b/BeastHttp/include/http/reactor/impl/listener.hxx
@@ -5,8 +5,8 @@
     template<template<typename> class OnAccept, \
     template<typename> class OnError, \
     class Protocol, \
-    template<typename> class Acceptor, \
-    template<typename> class Socket, \
+    class Acceptor, \
+    class Socket, \
     template<typename> class Endpoint>
 
 namespace _0xdead4ead {

--- a/BeastHttp/include/http/reactor/impl/session.hxx
+++ b/BeastHttp/include/http/reactor/impl/session.hxx
@@ -6,7 +6,7 @@
              class Fields, \
              class Buffer, \
              class Protocol, \
-             template<typename> class Socket, \
+             class Socket, \
              class Clock, \
              template<typename, typename...> class Timer, \
              template<typename> class Entry, \

--- a/BeastHttp/include/http/reactor/listener.hxx
+++ b/BeastHttp/include/http/reactor/listener.hxx
@@ -20,8 +20,8 @@ namespace reactor {
 template<template<typename> class OnAccept = std::function,
          template<typename> class OnError = std::function,
          class Protocol = boost::asio::ip::tcp,
-         template<typename> class Acceptor = boost::asio::basic_socket_acceptor,
-         template<typename> class Socket = boost::asio::basic_stream_socket,
+         class Acceptor = boost::asio::basic_socket_acceptor<Protocol>,
+         class Socket = boost::asio::basic_stream_socket<Protocol>,
          template<typename> class Endpoint = boost::asio::ip::basic_endpoint>
 class listener : public std::enable_shared_from_this<listener<BEASTHTTP_REACTOR_LISTENER_TMPL_ATTRIBUTES>>
         , boost::asio::coroutine
@@ -34,9 +34,9 @@ public:
 
     using protocol_type = Protocol;
 
-    using acceptor_type = Acceptor<protocol_type>;
+    using acceptor_type = Acceptor;
 
-    using socket_type = Socket<protocol_type>;
+    using socket_type = Socket;
 
     using endpoint_type = Endpoint<protocol_type>;
 

--- a/BeastHttp/include/http/reactor/session.hxx
+++ b/BeastHttp/include/http/reactor/session.hxx
@@ -1,6 +1,8 @@
 #if not defined BEASTHTTP_REACTOR_SESSION_HXX
 #define BEASTHTTP_REACTOR_SESSION_HXX
 
+#include <unordered_map>
+
 #include <http/base/cb.hxx>
 #include <http/base/request_processor.hxx>
 #include <http/base/queue.hxx>
@@ -44,7 +46,7 @@ template</*Prototype request message*/
          class Buffer = boost::beast::flat_buffer,
          /*Connection param's*/
          class Protocol = boost::asio::ip::tcp,
-         template<typename> class Socket = boost::asio::basic_stream_socket,
+         class Socket = boost::asio::basic_stream_socket<Protocol>,
          /*Timer param's*/
          class Clock = boost::asio::chrono::steady_clock,
          template<typename, typename...> class Timer = boost::asio::basic_waitable_timer,
@@ -100,7 +102,7 @@ public:
 
     using buffer_type = Buffer;
 
-    using connection_type = common::connection<Protocol, Socket, base::strand_stream::asio_type>;
+    using connection_type = common::connection<Socket, base::strand_stream::asio_type>;
 
     using socket_type = typename connection_type::socket_type;
 

--- a/BeastHttp/include/http/reactor/ssl/impl/session.hxx
+++ b/BeastHttp/include/http/reactor/ssl/impl/session.hxx
@@ -6,7 +6,7 @@
              class Fields, \
              class Buffer, \
              class Protocol, \
-             template<typename> class Socket, \
+             class Socket, \
              class Clock, \
              template<typename, typename...> class Timer, \
              template<typename> class Entry, \

--- a/BeastHttp/include/http/reactor/ssl/session.hxx
+++ b/BeastHttp/include/http/reactor/ssl/session.hxx
@@ -47,7 +47,7 @@ template</*Prototype request message*/
          class Buffer = boost::beast::flat_buffer,
          /*Connection param's*/
          class Protocol = boost::asio::ip::tcp,
-         template<typename> class Socket = boost::asio::basic_stream_socket,
+         class Socket = boost::asio::basic_stream_socket<Protocol>,
          /*Timer param's*/
          class Clock = boost::asio::chrono::steady_clock,
          template<typename, typename...> class Timer = boost::asio::basic_waitable_timer,
@@ -105,7 +105,7 @@ public:
 
     using buffer_type = Buffer;
 
-    using connection_type = common::ssl::connection<Protocol, Socket, base::strand_stream::asio_type>;
+    using connection_type = common::ssl::connection<Socket, base::strand_stream::asio_type>;
 
     using socket_type = typename connection_type::socket_type;
 


### PR DESCRIPTION
So, I really want to upgrade to Boost 1.70.0. However, BeastHttp uses template template parameters all over the place, expecting them to be compatible with templates from Boost. This is actually really brittle, as if the upstream template changes (and they did) then all of these template template parameters have to be updated.

This is also, honestly, "not terribly useful", as if I actually have a custom socket type (which I have done before), I would need to template your class over my custom type, not over the template of my custom type (which again, might take different template arguments). Essentially, I think the template design needs some work...

Regardless, this commit is intended to support Boost 1.70.0 not by hardcoding support for Boost 1.70.0 but instead generalizing some of the underlying templates. There is only one place I couldn't find a simple/elegant way to support old versions of Boost and new versions of Boost at the same time, and I added an #ifdef.

(FWIW, for my personal usage, I don't care if you drop support for old versions of Boost. I just didn't want "I can't compile or use the library for my own projects that are using an older version of Boost" or "I know someone who is using an old version of Boost" to block merging compatibility with newer versions of Boost ;P.)